### PR TITLE
release request after read in the simple API

### DIFF
--- a/matlab/nScopeReadAllChannels.m
+++ b/matlab/nScopeReadAllChannels.m
@@ -27,6 +27,6 @@ while(nScopeAPI('requestHasData'))
     data(i,4) = nScopeAPI('readData',4);
 end
 
-
+nScopeAPI('releaseRequest');
 end
 

--- a/matlab/nScopeReadCh1.m
+++ b/matlab/nScopeReadCh1.m
@@ -24,6 +24,6 @@ while(nScopeAPI('requestHasData'))
     data(i) = nScopeAPI('readData',1);
 end
 
-
+nScopeAPI('releaseRequest');
 end
 

--- a/python/nscopeapi/__init__.py
+++ b/python/nscopeapi/__init__.py
@@ -51,6 +51,7 @@ class nScope(
 		data = []
 		while self.requestHasData():
 			data.append(self.readData(1))
+		self.releaseRequest()
 		return data
 
 	def readCh2(self,numsamples,samplerate):
@@ -62,6 +63,7 @@ class nScope(
 		data = []
 		while self.requestHasData():
 			data.append(self.readData(2))
+		self.releaseRequest()
 		return data
 
 	def readCh3(self,numsamples,samplerate):
@@ -73,6 +75,7 @@ class nScope(
 		data = []
 		while self.requestHasData():
 			data.append(self.readData(3))
+		self.releaseRequest()
 		return data
 
 	def readCh4(self,numsamples,samplerate):
@@ -84,4 +87,5 @@ class nScope(
 		data = []
 		while self.requestHasData():
 			data.append(self.readData(4))
+		self.releaseRequest()
 		return data


### PR DESCRIPTION
I came across https://github.com/nLabs-nScope/nScopeAPI/issues/16 in a project recently, and after digging through the C api found that you have to release the request after use, causing the API to hang after 256 calls of the read API. I suspect that many students will use the simple read API (`readCh1`, 'readCh2', ...) when first using the nScope, so it'll be nice to add this fix to that interface so their programs won't hang. 